### PR TITLE
Add patch for numpy requirement

### DIFF
--- a/.scripts/logging_utils.sh
+++ b/.scripts/logging_utils.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Provide a unified interface for the different logging
+# utilities CI providers offer. If unavailable, provide
+# a compatible fallback (e.g. bare `echo xxxxxx`).
+
+function startgroup {
+    # Start a foldable group of log lines
+    # Pass a single argument, quoted
+    case ${CI:-} in
+        azure )
+            echo "##[group]$1";;
+        travis )
+            echo "$1"
+            echo -en 'travis_fold:start:'"${1// /}"'\\r';;
+        * )
+            echo "$1";;
+    esac
+}
+
+function endgroup {
+    # End a foldable group of log lines
+    # Pass a single argument, quoted
+    case ${CI:-} in
+        azure )
+            echo "##[endgroup]";;
+        travis )
+            echo -en 'travis_fold:end:'"${1// /}"'\\r';;
+    esac
+}

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -5,6 +5,10 @@
 # changes to this script, consider a proposal to conda-smithy so that other feedstocks can also
 # benefit from the improvement.
 
+source .scripts/logging_utils.sh
+
+startgroup "Configure Docker"
+
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
@@ -65,7 +69,9 @@ DOCKER_RUN_ARGS="${CONDA_FORGE_DOCKER_RUN_ARGS}"
 if [ -z "${CI}" ]; then
     DOCKER_RUN_ARGS="-it ${DOCKER_RUN_ARGS}"
 fi
+endgroup "Configure Docker"
 
+startgroup "Start Docker"
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) 2015-2020, conda-forge contributors
+Copyright (c) 2015-2021, conda-forge contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -187,9 +187,9 @@ build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase
-   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string).
+   the [``build/number``](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string).
  * If the version of a package **is** being increased, please remember to return
-   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string)
+   the [``build/number``](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string)
    back to 0.
 
 Feedstock Maintainers

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,14 +10,17 @@ source:
   sha256: 0519dda6d3a549621ec638a87eb2a0e8be4a4b50e9bc050bd1aaec3adab3054a
   patches:
     - openmp-macos.patch
+    # remove lalsuite requirement from python metadata
     - no-install_requires-lalsuite.patch
+    # update numpy requirements in python metadata to match conda
+    - numpy-requirement.patch
 
 build:
   error_overdepending: true
   error_overlinking: true
   ignore_run_exports:
     - python
-  number: 0
+  number: 1
   skip: true  # [win]
   script:
     - export CFLAGS="${CFLAGS} -fopenmp"  # [osx]
@@ -112,7 +115,11 @@ test:
     - fftw
     - mpi4py
     - openssh
+    - pip
   commands:
+    # check requirements with pip
+    - python -m pip check
+    # test scripts
     - export MPLBACKEND="agg"
     - pycbc_aligned_bank_cat --help
     - pycbc_aligned_stoch_bank --help

--- a/recipe/numpy-requirement.patch
+++ b/recipe/numpy-requirement.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index 56e252dd..f6815894 100755
+--- a/setup.py
++++ b/setup.py
+@@ -38,7 +38,7 @@ setup_requires = ['numpy>=1.16.0']
+ install_requires =  setup_requires + ['Mako>=1.0.1',
+                       'cython>=0.29',
+                       'decorator>=3.4.2',
+-                      'numpy>=1.16.0,!=1.19.0,<1.20.0; python_version >= "3.5"',
++                      'numpy>=1.16.0,!=1.19.0; python_version >= "3.5"',
+                       'numpy>=1.16.0,<1.17.0; python_version <= "2.7"',
+                       'scipy>=0.16.0; python_version >= "3.5"',
+                       'scipy>=0.16.0,<1.3.0; python_version <= "3.4"',


### PR DESCRIPTION
This PR fixes a mismatch in the specified `numpy` requirement between the python metadata and the conda metadata. The `<1.20` requirement is unnecessary for the conda package, but we need to patch it out in the python metadata properly to tell `pip` that we know what we're doing.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
