### PR TITLE
Skip flaky tests on zen2

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -40,7 +40,7 @@ source:
 build:
   dynamic_linking:
     overlinking_behavior: error
-  number: 0
+  number: 1
   script: ${{ PYTHON }} -m pip install . -vv
   skip:
     - win
@@ -156,10 +156,13 @@ tests:
     script:
       # Skip test_bhspec.py (see https://github.com/gwastro/pycbc/issues/5246)
       - "export PYTEST_ADDOPTS=\"--ignore test/test_bhspec.py\""
+      # Skip flaky tests on zen2 (see https://github.com/gwastro/pycbc/issues/5259)
+      - "if [[ \"$(conda info)\" == *\"zen2\"* ]]; then export PYTEST_ADDOPTS=\"${PYTEST_ADDOPTS:-} -k 'not test_perfect_match'\"; fi"
       # Skip test_fft_mkl_threaded.py on non-x86_64 platforms
       - if: unix and not x86_64
         then: "export PYTEST_ADDOPTS=\"${PYTEST_ADDOPTS:-} --ignore test/test_fft_mkl_threaded.py\""
       # Run test suite
+      - echo "PYTEST_ADDOPTS=${PYTEST_ADDOPTS:-}"
       - python -m pytest test/ -n ${{ env.get("CPU_COUNT", default="1") }}
       # Check that command-line scripts are functional
       - "export MPLBACKEND=\"agg\""


### PR DESCRIPTION
This PR works around the test failures on zen2, see https://github.com/gwastro/pycbc/issues/5259.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
